### PR TITLE
Add TraitsDebugger and move traits-demography alignment into traits.py

### DIFF
--- a/stdpopsim/slim_engine.py
+++ b/stdpopsim/slim_engine.py
@@ -558,8 +558,13 @@ _slim_main = """
             +     "if (isNULL(" + population_id + ")) {"
             +         "affected_inds = sim.subpopulations.individuals;"
             +     "} else {"
-            +         "affected_inds = p" + population_id + ".individuals;"
+                      // look the population up by id, since it may not
+                      // exist during the whole interval
+            +         "sp = sim.subpopulations[sim.subpopulations.id == "
+            +             population_id + "];"
+            +         "affected_inds = sp.individuals;"
             +     "}"
+            +     "if (size(affected_inds) == 0) return;"
             +     "if (env_dist[" + i + "] == 'mvn') {"
             +         "dparams = env_params.getValue(" + i + ");"
             +         "env_effect_means = dparams.getValue('means');"
@@ -1098,113 +1103,6 @@ def _check_traits_model_contig_consistency(contig, traits_model):
         )
 
 
-def _collect_valid_population_intervals(demographic_model):
-    # First, figure out when populations are around
-    # TODO: this might be wrong if there's a population that's not active at
-    # the present.
-    accessible_demes = demographic_model.model.debug().possible_lineage_locations(
-        [
-            msprime.SampleSet(1, population=p.id, time=0)
-            for p in demographic_model.populations
-        ]
-    )
-    # Collect valid population intervals and record simulation start
-    valid_times = {population.id: [] for population in demographic_model.populations}
-    oldest_time = 0
-    for interval, mask in accessible_demes.items():
-        oldest_time = max(oldest_time, interval[1])
-        for i, active in enumerate(mask):
-            if active:
-                valid_times[i].append(list(interval))
-
-    # Replace simulation start time with infinity (ensures that initial
-    # populations are allowed to have condition intervals ending at infinity)
-    for intervals in valid_times.values():
-        for interval in intervals:
-            if interval[1] == oldest_time:
-                interval[1] = float("inf")
-
-    # merge adjacent intervals for convenience for later
-    for k in valid_times:
-        valid_times[k] = list(sorted(valid_times[k]))
-        cleaned_intervals = [valid_times[k][0]]
-        for interval in valid_times[k][1:]:
-            if interval[0] == cleaned_intervals[-1][1]:
-                assert interval[1] >= cleaned_intervals[-1][1]
-                cleaned_intervals[-1][1] = interval[1]
-            else:
-                cleaned_intervals.append(interval)
-        valid_times[k] = cleaned_intervals
-    return valid_times
-
-
-def _standardize_condition(condition, valid_intervals):
-    new_conditions = []
-    if condition.population_list is None:
-        new_conditions.append(copy.deepcopy(condition))
-    for p in condition.population_list:
-        if p not in valid_intervals:
-            raise ValueError("Population index out of bounds.")
-        standardized = []
-        if condition.time_intervals is None:
-            standardized.extend(valid_intervals[p])
-        else:
-            for interval in condition.time_intervals:
-                is_valid = False
-                if interval[1] != float("inf"):
-                    # If interval is finite, we must identify
-                    # a model interval that contains it
-                    for demo_interval in valid_intervals[p]:
-                        if (
-                            interval[0] >= demo_interval[0]
-                            and interval[1] <= demo_interval[1]
-                        ):
-                            is_valid = True
-                            standardized.append(interval)
-                else:
-                    # If interval is infinite, we must identify
-                    # all overlapping model intervals
-                    for demo_interval in valid_intervals[p]:
-                        if interval[0] < demo_interval[0]:
-                            standardized.append(demo_interval)
-                            is_valid = True
-                        elif (
-                            interval[0] >= demo_interval[0]
-                            and interval[0] < demo_interval[1]
-                        ):
-                            standardized.append([interval[0], demo_interval[1]])
-                            is_valid = True
-                if not is_valid:
-                    raise ValueError(
-                        "An environment or a fitness function was "
-                        "specified for a population with a time interval "
-                        "during which that population does not exist."
-                    )
-        p_copy = copy.deepcopy(condition)
-        p_copy.population_list = [p]
-        p_copy.time_intervals = standardized
-        new_conditions.append(p_copy)
-
-    return new_conditions
-
-
-# TODO: write tests for this in test_slim_engine.py
-def _align_traits_model_demography(traits_model, demographic_model):
-    valid_intervals = _collect_valid_population_intervals(demographic_model)
-
-    # Loop through environments & fitness functions and rewrite time intervals
-    # to be consistent with the demographic model
-    new_env = []
-    for env in traits_model.environments:
-        new_env.extend(_standardize_condition(env, valid_intervals))
-    traits_model.environments = new_env
-
-    new_ff = []
-    for ff in traits_model.fitness_functions:
-        new_ff.extend(_standardize_condition(ff, valid_intervals))
-    traits_model.fitness_functions = new_ff
-
-
 def slim_makescript(
     script_file,
     trees_file,
@@ -1224,34 +1122,13 @@ def slim_makescript(
 
     if traits_model is None:
         traits_model = stdpopsim.TraitsModel()
-    else:
-        # Copy the traits model so that messing with population IDs doesn't
-        # mess with the user's traits_model.
-        traits_model = copy.deepcopy(traits_model)
-        for event in traits_model.environments + traits_model.fitness_functions:
-            if event.population_list is not None:
-                pop_id_list = []
-                for population in event.population_list:
-                    if isinstance(population, int):
-                        if population >= len(pop_names) or population < 0:
-                            raise ValueError("Population index out of bounds.")
-                        pop_id_list.append(population)
-                    elif isinstance(population, str):
-                        try:
-                            pop_id_list.append(pop_names.index(population))
-                        except ValueError:
-                            raise ValueError(
-                                "Population label supplied not in" "demographic model."
-                            )
-                    else:
-                        # this should not happen given the checks in traits.py
-                        assert False
-                if len(pop_id_list) != len(set(pop_id_list)):
-                    raise ValueError("Repeated population indices.")
-            event.population_list = pop_id_list
 
     _check_traits_model_contig_consistency(contig, traits_model)
-    _align_traits_model_demography(traits_model, demographic_model)
+    # Alignment returns a rewritten copy, so the user's traits_model is
+    # left untouched.
+    traits_model = stdpopsim.traits._align_traits_model_demography(
+        traits_model, demographic_model
+    )
 
     # Use copies of these so that the time frobbing below doesn't have
     # side-effects in the caller's model.

--- a/stdpopsim/traits.py
+++ b/stdpopsim/traits.py
@@ -3,6 +3,7 @@ Methods related to traits and effects of mutations on them,
 including environment and fitness (so, this includes DFE machinery).
 """
 
+import copy
 import textwrap
 import attr
 import collections.abc
@@ -926,3 +927,369 @@ def _check_distribution(distribution_type, distribution_args, dim):
         _check_gaussian_args(distribution_args, dim)
     else:
         raise ValueError(f"{distribution_type} is not a supported distribution type.")
+
+
+def _resolve_population_ids(traits_model, demographic_model):
+    # Rewrite each condition's population_list, in place, so that
+    # populations are integer indices into the demographic model's
+    # population list.
+    pop_names = [pop.name for pop in demographic_model.model.populations]
+    for event in traits_model.environments + traits_model.fitness_functions:
+        if event.population_list is None:
+            continue
+        pop_id_list = []
+        for population in event.population_list:
+            if isinstance(population, int):
+                if population >= len(pop_names) or population < 0:
+                    raise ValueError("Population index out of bounds.")
+                pop_id_list.append(population)
+            else:
+                try:
+                    pop_id_list.append(pop_names.index(population))
+                except ValueError:
+                    raise ValueError(
+                        "Population label supplied not in demographic model."
+                    )
+        if len(pop_id_list) != len(set(pop_id_list)):
+            raise ValueError("Repeated population indices.")
+        event.population_list = pop_id_list
+
+
+def _collect_valid_population_intervals(demographic_model, debugger=None):
+    # Return a dict mapping population id to a list of [start, end) time
+    # intervals (in generations, backward in time) during which that
+    # population is active. The oldest interval ends at infinity.
+    if debugger is None:
+        debugger = demographic_model.model.debug()
+    valid_times = {p.id: [] for p in demographic_model.model.populations}
+    for epoch in debugger.epochs:
+        for pop in epoch.populations:
+            if not pop.active:
+                continue
+            intervals = valid_times[pop.id]
+            if intervals and intervals[-1][1] == epoch.start_time:
+                intervals[-1][1] = epoch.end_time
+            else:
+                intervals.append([epoch.start_time, epoch.end_time])
+    return valid_times
+
+
+def _standardize_condition(condition, valid_intervals):
+    # Split a condition into one copy per population, with time intervals
+    # made explicit: intervals ending at infinity are clipped to the
+    # times the population is active, and finite intervals are required
+    # to fall entirely within such times. A condition without populations
+    # applies to every population that is active during its times, so it
+    # is expanded into per-population copies whose intervals are clipped
+    # to each population's activity; populations with no overlap are
+    # dropped rather than being an error.
+    if condition.population_list is None:
+        intervals = condition.time_intervals
+        if intervals is None:
+            intervals = [[0, float("inf")]]
+        new_conditions = []
+        for p, activity in valid_intervals.items():
+            clipped = []
+            for a, b in intervals:
+                for c, d in activity:
+                    lo, hi = max(a, c), min(b, d)
+                    if lo < hi:
+                        clipped.append([lo, hi])
+            if clipped:
+                p_copy = copy.deepcopy(condition)
+                p_copy.population_list = [p]
+                p_copy.time_intervals = clipped
+                new_conditions.append(p_copy)
+        return new_conditions
+    new_conditions = []
+    for p in condition.population_list:
+        if p not in valid_intervals:
+            raise ValueError("Population index out of bounds.")
+        standardized = []
+        if condition.time_intervals is None:
+            standardized.extend(valid_intervals[p])
+        else:
+            for interval in condition.time_intervals:
+                is_valid = False
+                if interval[1] != float("inf"):
+                    # If interval is finite, we must identify
+                    # a model interval that contains it
+                    for demo_interval in valid_intervals[p]:
+                        if (
+                            interval[0] >= demo_interval[0]
+                            and interval[1] <= demo_interval[1]
+                        ):
+                            is_valid = True
+                            standardized.append(interval)
+                else:
+                    # If interval is infinite, we must identify
+                    # all overlapping model intervals
+                    for demo_interval in valid_intervals[p]:
+                        if interval[0] < demo_interval[0]:
+                            standardized.append(demo_interval)
+                            is_valid = True
+                        elif (
+                            interval[0] >= demo_interval[0]
+                            and interval[0] < demo_interval[1]
+                        ):
+                            standardized.append([interval[0], demo_interval[1]])
+                            is_valid = True
+                if not is_valid:
+                    raise ValueError(
+                        "An environment or a fitness function was "
+                        "specified for a population with a time interval "
+                        "during which that population does not exist."
+                    )
+        p_copy = copy.deepcopy(condition)
+        p_copy.population_list = [p]
+        p_copy.time_intervals = standardized
+        new_conditions.append(p_copy)
+
+    return new_conditions
+
+
+def _align_traits_model_demography(traits_model, demographic_model, debugger=None):
+    # Return a copy of ``traits_model`` in which every environment and
+    # fitness function has a single integer population id and explicit
+    # time intervals consistent with the demographic model.
+    traits_model = copy.deepcopy(traits_model)
+    if not traits_model.environments and not traits_model.fitness_functions:
+        return traits_model
+    _resolve_population_ids(traits_model, demographic_model)
+    valid_intervals = _collect_valid_population_intervals(demographic_model, debugger)
+    new_env = []
+    for env in traits_model.environments:
+        new_env.extend(_standardize_condition(env, valid_intervals))
+    traits_model.environments = new_env
+
+    new_ff = []
+    for ff in traits_model.fitness_functions:
+        new_ff.extend(_standardize_condition(ff, valid_intervals))
+    traits_model.fitness_functions = new_ff
+    return traits_model
+
+
+# The next two functions are copied from msprime/core.py (GPL-3), so
+# that our tables render in the same style as msprime's
+# DemographyDebugger.
+
+
+def _text_table_row(data, alignments, widths):
+    num_lines = max(len(item) for item in data)
+    for item in data:
+        assert isinstance(item, list)
+        item.extend([""] * (num_lines - len(item)))
+        assert len(item) == num_lines
+    s = ""
+    for line in range(num_lines):
+        out_line = "│"
+        for value, align, width in zip(data, alignments, widths):
+            out_line += f"{value[line]:{align}{width - 1}}│"
+        out_line += "\n"
+        s += out_line
+    return s
+
+
+def _text_table(caption, column_titles, column_alignments, data):
+    N = len(column_titles)
+    assert len(column_alignments) == N
+    widths = np.array([len(title) for title in column_titles], dtype=int)
+    for row in data + [column_titles]:
+        assert N == len(row)
+        for j in range(N):
+            widths[j] = max(widths[j], max((len(line) for line in row[j]), default=0))
+    widths += 3
+
+    hline = "─" * (sum(widths) - 1)
+    out = f"{caption}\n"
+    out += f"┌{hline}┐\n"
+    out += f"{_text_table_row(column_titles, column_alignments, widths)}"
+    out += f"├{hline}┤\n"
+    for split_row in data:
+        out += f"{_text_table_row(split_row, column_alignments, widths)}"
+    out += f"└{hline}┘\n"
+    return out
+
+
+class TraitsDebugger:
+    """
+    Shows how a :class:`.TraitsModel` lines up with a demographic model,
+    in the style of ``msprime.DemographyDebugger``. One table is printed
+    per time interval within which both the demography and the set of
+    applicable environments and fitness functions are constant, so
+    epochs of the demographic model are split wherever an environment or
+    a fitness function starts or ends.
+
+    The environments and fitness functions shown are the standardized
+    ones, i.e. after populations are resolved and time intervals are
+    made consistent with the demographic model. This is how the
+    simulation engine interprets them.
+
+    :param demographic_model: A :class:`.DemographicModel`.
+    :param traits_model: A :class:`.TraitsModel`, or None for a plain
+        demography table.
+    """
+
+    def __init__(self, demographic_model, traits_model=None):
+        self.demographic_model = demographic_model
+        if traits_model is None:
+            traits_model = TraitsModel()
+        self._demography_debugger = demographic_model.model.debug()
+        self.traits_model = _align_traits_model_demography(
+            traits_model, demographic_model, self._demography_debugger
+        )
+        # After alignment, every condition has a single population and
+        # explicit time intervals.
+        for condition in self._conditions():
+            assert len(condition.population_list) == 1
+            assert condition.time_intervals is not None
+        self._make_epochs()
+
+    def _conditions(self):
+        return self.traits_model.environments + self.traits_model.fitness_functions
+
+    def _make_epochs(self):
+        dd = self._demography_debugger
+        breaks = {epoch.start_time for epoch in dd.epochs}
+        for condition in self._conditions():
+            for start, end in condition.time_intervals:
+                breaks.add(start)
+                if np.isfinite(end):
+                    breaks.add(end)
+        breaks = sorted(breaks)
+        sizes = dd.population_size_trajectory(breaks)
+        self._epochs = []
+        for i, start in enumerate(breaks):
+            end = breaks[i + 1] if i + 1 < len(breaks) else float("inf")
+            parent = next(e for e in dd.epochs if e.start_time <= start < e.end_time)
+            # Sizes at the parent's own boundaries come from the parent,
+            # so that instantaneous size changes display as in msprime.
+            start_sizes = {}
+            end_sizes = {}
+            for pop in parent.populations:
+                if start == parent.start_time:
+                    start_sizes[pop.id] = pop.start_size
+                else:
+                    start_sizes[pop.id] = sizes[i][pop.id]
+                if end == parent.end_time:
+                    end_sizes[pop.id] = pop.end_size
+                else:
+                    end_sizes[pop.id] = sizes[i + 1][pop.id]
+            self._epochs.append(
+                dict(
+                    start=start,
+                    end=end,
+                    parent=parent,
+                    start_sizes=start_sizes,
+                    end_sizes=end_sizes,
+                )
+            )
+
+    def _active_condition_ids(self, conditions, pop_id, start, end):
+        ids = []
+        for condition in conditions:
+            if pop_id not in condition.population_list:
+                continue
+            for a, b in condition.time_intervals:
+                if a <= start and end <= b:
+                    ids.append(condition.id)
+                    break
+        return ids
+
+    def _populations_text(self, epoch):
+        parent = epoch["parent"]
+        column_titles = [
+            [""],
+            ["start"],
+            ["end"],
+            ["growth_rate"],
+            ["environments"],
+            ["fitness_functions"],
+        ]
+        data = []
+        for pop in parent.populations:
+            if not pop.active:
+                continue
+            envs = self._active_condition_ids(
+                self.traits_model.environments, pop.id, epoch["start"], epoch["end"]
+            )
+            ffs = self._active_condition_ids(
+                self.traits_model.fitness_functions,
+                pop.id,
+                epoch["start"],
+                epoch["end"],
+            )
+            data.append(
+                [
+                    [pop.name],
+                    [f"{epoch['start_sizes'][pop.id]: .1f}"],
+                    [f"{epoch['end_sizes'][pop.id]: .1f}"],
+                    [f"{pop.growth_rate: .3g}"],
+                    envs if envs else [""],
+                    ffs if ffs else [""],
+                ]
+            )
+        caption = (
+            f"Populations (total={len(parent.populations)} "
+            f"active={parent.num_active_populations})"
+        )
+        return _text_table(caption, column_titles, ">>><^^", data)
+
+    def _burn_in_note(self):
+        oldest_event = max(e.start_time for e in self._demography_debugger.epochs)
+        oldest_time = oldest_event
+        oldest_id = None
+        for condition in self._conditions():
+            for interval in condition.time_intervals:
+                for t in interval:
+                    if np.isfinite(t) and t > oldest_time:
+                        oldest_time = t
+                        oldest_id = condition.id
+        if oldest_id is None:
+            return ""
+        return (
+            f"Burn-in ends {oldest_time:.3g} generations ago, set by "
+            f"'{oldest_id}' (the oldest demographic event is "
+            f"{oldest_event:.3g} generations ago).\n"
+        )
+
+    def print_history(self, output=None):
+        """
+        Prints the decorated demography table to the given file object,
+        or to stdout if none is given.
+        """
+        print(self, file=output, end="")
+
+    def __str__(self):
+        # The box-drawing glue below is copied from
+        # msprime.DemographyDebugger.__str__ (GPL-3).
+        def indent(table, header_char="╟", depth=4):
+            lines = table.splitlines()
+            s = header_char + (" " * depth) + lines[0] + "\n"
+            for line in lines[1:]:
+                s += "║" + (" " * depth) + line + "\n"
+            return s
+
+        def box(title):
+            N = len(title) + 2
+            top = "╠" + ("═" * N) + "╗"
+            bottom = "╠" + ("═" * N) + "╝"
+            return f"{top}\n║ {title} ║\n{bottom}\n"
+
+        out = "TraitsDebugger\n"
+        out += self._burn_in_note()
+        for i, epoch in enumerate(self._epochs):
+            parent = epoch["parent"]
+            if epoch["start"] > 0 and epoch["start"] == parent.start_time:
+                title = f"Events @ generation {epoch['start']:.3g}"
+                out += indent(
+                    self.demographic_model.model._events_text(parent.events, title)
+                )
+            title = (
+                f"Epoch[{i}]: [{epoch['start']:.3g}, {epoch['end']:.3g}) " "generations"
+            )
+            if np.isinf(epoch["end"]):
+                title += " (includes burn-in)"
+            out += box(title)
+            out += indent(self._populations_text(epoch))
+        return out

--- a/tests/test_traits_debugger.py
+++ b/tests/test_traits_debugger.py
@@ -1,0 +1,187 @@
+"""
+Tests for the traits debugger and for aligning traits models
+with demographic models.
+"""
+
+import io
+
+import msprime
+import numpy as np
+import pytest
+
+import stdpopsim
+from stdpopsim import traits
+
+
+def split_model():
+    # A and B split from anc 3000 generations ago.
+    d = msprime.Demography()
+    d.add_population(name="A", initial_size=1000)
+    d.add_population(name="B", initial_size=500)
+    d.add_population(name="anc", initial_size=800)
+    d.add_population_split(time=3000, derived=["A", "B"], ancestral="anc")
+    return stdpopsim.DemographicModel(
+        id="test_model",
+        description="test",
+        long_description="test",
+        generation_time=1,
+        model=d,
+    )
+
+
+def traits_model(**condition_kwargs):
+    tm = stdpopsim.TraitsModel(traits=[stdpopsim.Trait(id="add1", type="additive")])
+    tm.add_fitness_function(
+        id="fit1",
+        trait_ids=["add1"],
+        function_type="gaussian",
+        function_args=[np.zeros(1), np.eye(1)],
+        **condition_kwargs,
+    )
+    return tm
+
+
+class TestCollectValidPopulationIntervals:
+    def test_split_model(self):
+        got = traits._collect_valid_population_intervals(split_model())
+        assert got == {
+            0: [[0, 3000]],
+            1: [[0, 3000]],
+            2: [[3000, float("inf")]],
+        }
+
+    def test_populations_inactive_at_present(self):
+        # Ancestral populations must not be reported as active at recent
+        # times, and ancient default sampling times must not hide the
+        # recent activity of present-day populations.
+        species = stdpopsim.get_species("HomSap")
+        dm = species.get_demographic_model("AncientEurope_4A21")
+        got = traits._collect_valid_population_intervals(dm)
+        by_name = {p.name: p.id for p in dm.model.populations}
+        assert got[by_name["OOA"]] == [[1500, float("inf")]]
+        assert got[by_name["NE"]] == [[600, 1500]]
+        assert got[by_name["Bronze"]] == [[0, 140]]
+
+
+class TestAlignTraitsModelDemography:
+    def align(self, tm):
+        return traits._align_traits_model_demography(tm, split_model())
+
+    def test_resolves_population_names(self):
+        tm = self.align(traits_model(time_intervals=[(0, 1000)], population_list=["A"]))
+        assert tm.fitness_functions[0].population_list == [0]
+
+    def test_no_population_list_expanded(self):
+        # A condition without populations applies to every population
+        # active during its times, clipped to each one's activity.
+        tm = self.align(traits_model(time_intervals=[(0, 4000)]))
+        by_pop = {ff.population_list[0]: ff for ff in tm.fitness_functions}
+        assert set(by_pop) == {0, 1, 2}
+        assert by_pop[0].time_intervals == [[0, 3000]]
+        assert by_pop[1].time_intervals == [[0, 3000]]
+        assert by_pop[2].time_intervals == [[3000, 4000]]
+
+    def test_no_population_list_drops_inactive(self):
+        # anc is not active on [0, 1000), so it gets no copy.
+        tm = self.align(traits_model(time_intervals=[(0, 1000)]))
+        by_pop = {ff.population_list[0]: ff for ff in tm.fitness_functions}
+        assert set(by_pop) == {0, 1}
+
+    def test_no_population_list_no_times(self):
+        tm = self.align(traits_model(time_intervals=None))
+        by_pop = {ff.population_list[0]: ff for ff in tm.fitness_functions}
+        assert set(by_pop) == {0, 1, 2}
+        assert by_pop[0].time_intervals == [[0, 3000]]
+        assert by_pop[2].time_intervals == [[3000, float("inf")]]
+
+    def test_infinite_interval_clipped(self):
+        tm = self.align(
+            traits_model(time_intervals=[(0, float("inf"))], population_list=["B"])
+        )
+        assert tm.fitness_functions[0].time_intervals == [[0, 3000]]
+
+    def test_finite_interval_outside_population(self):
+        with pytest.raises(ValueError, match="does not exist"):
+            self.align(traits_model(time_intervals=[(0, 4000)], population_list=["B"]))
+
+    def test_bad_population_name(self):
+        with pytest.raises(ValueError, match="not in demographic model"):
+            self.align(traits_model(population_list=["nope"]))
+
+    def test_bad_population_index(self):
+        with pytest.raises(ValueError, match="out of bounds"):
+            self.align(traits_model(population_list=[3]))
+
+
+class TestTraitsDebugger:
+    def epochs_text(self, dbg):
+        # Split the printed output into one chunk per epoch box.
+        chunks = str(dbg).split("Epoch[")
+        return chunks[0], chunks[1:]
+
+    def test_no_traits_model(self):
+        dm = split_model()
+        dbg = stdpopsim.TraitsDebugger(dm)
+        head, epochs = self.epochs_text(dbg)
+        assert len(epochs) == len(dm.model.debug().epochs)
+        assert "Burn-in" not in head
+
+    def test_epochs_split_at_condition_boundaries(self):
+        tm = traits_model(time_intervals=[(0, 1000)])
+        tm.add_environment(
+            id="env1",
+            trait_ids=["add1"],
+            distribution_type="mvn",
+            distribution_args=[np.zeros(1), np.eye(1)],
+            time_intervals=[(0, float("inf"))],
+            population_list=["A"],
+        )
+        dbg = stdpopsim.TraitsDebugger(split_model(), tm)
+        head, epochs = self.epochs_text(dbg)
+        # [0, 1000), [1000, 3000), [3000, inf)
+        assert len(epochs) == 3
+        assert "fit1" in epochs[0]
+        assert "fit1" not in epochs[1]
+        assert "fit1" not in epochs[2]
+        # env1 is clipped to the times A is active
+        assert "env1" in epochs[0]
+        assert "env1" in epochs[1]
+        assert "env1" not in epochs[2]
+
+    def test_infinite_interval_includes_burn_in(self):
+        tm = traits_model(time_intervals=[(0, float("inf"))])
+        _, epochs = self.epochs_text(stdpopsim.TraitsDebugger(split_model(), tm))
+        assert all("fit1" in epoch for epoch in epochs)
+        assert "includes burn-in" in epochs[-1]
+        assert sum("includes burn-in" in epoch for epoch in epochs) == 1
+
+    def test_burn_in_note(self):
+        tm = traits_model(time_intervals=[(3000, 4000)], population_list=["anc"])
+        dbg = stdpopsim.TraitsDebugger(split_model(), tm)
+        head, epochs = self.epochs_text(dbg)
+        assert "Burn-in ends 4e+03" in head
+        assert "'fit1'" in head
+        # the extra breakpoint at 4000 splits the oldest epoch
+        assert len(epochs) == 3
+        assert "fit1" not in epochs[0]
+        assert "fit1" in epochs[1]
+        assert "fit1" not in epochs[2]
+
+    def test_input_model_not_mutated(self):
+        tm = traits_model(time_intervals=[(0, float("inf"))], population_list=["A"])
+        stdpopsim.TraitsDebugger(split_model(), tm)
+        assert tm.fitness_functions[0].population_list == ["A"]
+        assert tm.fitness_functions[0].time_intervals == [(0, float("inf"))]
+
+    def test_print_history(self):
+        dbg = stdpopsim.TraitsDebugger(split_model(), traits_model())
+        buf = io.StringIO()
+        dbg.print_history(buf)
+        assert buf.getvalue() == str(dbg)
+
+    def test_catalog_model(self):
+        species = stdpopsim.get_species("HomSap")
+        dm = species.get_demographic_model("AncientEurope_4A21")
+        out = str(stdpopsim.TraitsDebugger(dm))
+        assert "Bronze" in out
+        assert "includes burn-in" in out


### PR DESCRIPTION
## TraitsDebugger

This implements the `TraitsDebugger` discussed in #1861, as a branch off #1860. It adds a debugger that shows how a `TraitsModel` lines up with a demographic model, and it moves the alignment machinery from `slim_engine.py` into `traits.py` so the debugger and the engine interpret conditions with the same code.

### The debugger

`stdpopsim.TraitsDebugger(demographic_model, traits_model)` prints msprime-style epoch tables with two new columns, `environments` and `fitness_functions`. Epochs are split wherever a condition starts or ends, so every box shows a constant demography and a constant set of active conditions. The conditions shown are the standardized ones (after populations are resolved and intervals are clipped), i.e. what the engine will actually do. The oldest epoch is labeled as including burn-in, and a header note reports when the traits model, not the demography, sets the end of burn-in.

Example: for a model where A and B split from anc 3,000 generations ago, with `env1` on A over `[0, 1000)`, `fit1` everywhere over `[0, inf)`, and `fit2` on anc over `[3000, 4000)`:

```
TraitsDebugger
Burn-in ends 4e+03 generations ago, set by 'fit2' (the oldest demographic event is 3e+03 generations ago).
╠══════════════════════════════════╗
║ Epoch[0]: [0, 1e+03) generations ║
╠══════════════════════════════════╝
╟    Populations (total=3 active=2)
║    ┌────────────────────────────────────────────────────────────────────────┐
║    │   │    start│      end│growth_rate  │ environments │ fitness_functions │
║    ├────────────────────────────────────────────────────────────────────────┤
║    │  A│   1000.0│   1000.0│ 0           │     env1     │       fit1        │
║    │  B│    500.0│    500.0│ 0           │              │       fit1        │
║    └────────────────────────────────────────────────────────────────────────┘
...
╠═══════════════════════════════════════════════════════╗
║ Epoch[3]: [4e+03, inf) generations (includes burn-in) ║
╠═══════════════════════════════════════════════════════╝
```

The table rendering is copied from msprime's `core.py` so the output style matches the `DemographyDebugger`. Text output only for now; a `_repr_html_` for notebooks would be easy to add later if we want it.

### Moves and fixes that came with it

- `_align_traits_model_demography`, `_standardize_condition`, and `_collect_valid_population_intervals` now live in `traits.py` (as discussed in #1861), and `slim_makescript` calls them there. Alignment now returns a standardized copy rather than mutating in place.
- Population activity intervals now come from `demography.debug().epochs` (per-epoch `active` flags) instead of `possible_lineage_locations`. The lineage-locations approach reported ancestral populations as present at all times (a lineage parked in an inactive population never moves), so validation accepted conditions on times where the population does not exist. This fixes the TODO about populations that are not active at the present.
- `population_list=None` now works. Previously the first `None` condition raised `NameError`, and later ones silently inherited the previous condition's populations. A `None` condition is now expanded into per-population copies clipped to each population's activity, matching the documented "applies to all active populations" semantics and the engine's one-population-per-condition table format.
- The environment events in the SLiM template look up subpopulations by id and skip populations that do not exist at the current tick, instead of referencing `pN` symbols that may be undefined.

### Points I want your eyes on

1. **What does "the population exists" mean for old-style models?** For models built from `population_configurations` + mass migrations (e.g. `OutOfAfrica_3G09`), msprime considers every population active at all times, so `[0, inf)` conditions no longer clip at the mass-migration times. The SLiM translation still creates those subpopulations at their split times, so the runtime test above is what keeps the two views compatible: the condition simply has no effect while the subpopulation does not exist. Consequence: for old-style models, a finite interval outside a population's SLiM lifetime is a no-op rather than an error. If we want strict errors there too, the engine would need to validate against its own `N > 0` epochs rather than msprime activity; I'm happy to discuss where that would go.
2. **The `isNULL(population_id)` branch in the environment template is now dead**, since `None` conditions are expanded before emission and `env_pops` is always integer. I left it in place because it looks like an intentional design for all-population conditions; if you would rather keep `NULL` entries in `env_pops` and skip the expansion, that works too, and I can rework it.
3. **The debugger's burn-in note re-derives the `max_tm_time` rule** that `slim_makescript` computes inline. I did not consolidate them to avoid churning the emission code while you are working on it, but they should eventually share one helper in `traits.py` so the debugger cannot drift from the engine.

### Testing

- `tests/test_traits_debugger.py` covers the debugger, the activity intervals (including `AncientEurope_4A21` regression for populations inactive at the present), the `None` expansion, and the interval-clipping semantics. 73 traits tests pass.
- To run the SLiM-executing tests I built the `multitrait` SLiM branch and installed pyslim from git head — note that PyPI pyslim 1.1.1 lacks `add_mutation_metadata`, which I think is why CI is red on #1860. With that toolchain, `TestTraits::test_traits_deepcopy` (3G09 with environments from tick 1) runs through SLiM cleanly, which exercises the existence guard end to end. The remaining `TestTraits` failures are identical on the base branch (version skew between SLiM head and pyslim head in the metadata code), so they are environmental, not from this change.
